### PR TITLE
Add dependency lock file and workflow check

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -23,6 +23,13 @@ jobs:
         node-version: '18'
         cache: 'npm'
 
+    - name: Check for dependency lock file
+      run: |
+        if [ ! -f package-lock.json ] && [ ! -f yarn.lock ]; then
+          echo "❌ Dependency lock file is missing!"
+          exit 1
+        fi
+
     - name: Install dependencies
       run: npm ci
 
@@ -138,6 +145,13 @@ jobs:
         node-version: '18'
         cache: 'npm'
 
+    - name: Check for dependency lock file
+      run: |
+        if [ ! -f package-lock.json ] && [ ! -f yarn.lock ]; then
+          echo "❌ Dependency lock file is missing!"
+          exit 1
+        fi
+
     - name: Install dependencies
       run: npm ci
 
@@ -151,6 +165,13 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.base_ref }}
+
+    - name: Check for dependency lock file
+      run: |
+        if [ ! -f package-lock.json ] && [ ! -f yarn.lock ]; then
+          echo "❌ Dependency lock file is missing!"
+          exit 1
+        fi
 
     - name: Install dependencies (base)
       run: npm ci


### PR DESCRIPTION
I generated package-lock.json to ensure consistent dependency installation.

I updated the GitHub workflow (.github/workflows/performance.yml) to include a step that checks for the presence of a dependency lock file (package-lock.json or yarn.lock) before attempting to install dependencies. This will cause the workflow to fail fast if the lock file is missing.